### PR TITLE
feat(filter) adds host severity filter and a bit of code refact

### DIFF
--- a/hostgroup-monitoring/configs.xml
+++ b/hostgroup-monitoring/configs.xml
@@ -12,6 +12,7 @@
     <autoRefresh>10</autoRefresh>
     <preferences>
         <preference label="Hostgroup Name Search" name="hg_name_search" defaultValue="" type="compare" header="Filters"/>
+        <preference label="Host Severity" name="host_severity" defaultValue="" type="hostCategory"/>
         <preference label="Enable Detailed Mode" name="enable_detailed_mode" defaultValue="0" type="boolean"/>
         <preference label="Display alias instead of name for hosts" name="display_host_alias" defaultValue="0" type="boolean"/>
         <preference label="Results" name="entries" defaultValue="20" type="range" min="10" max="100" step="10"/>

--- a/hostgroup-monitoring/data.js
+++ b/hostgroup-monitoring/data.js
@@ -33,26 +33,25 @@
  */
 
 jQuery(function () {
-    loadPage();
+  loadPage();
 });
 
 /**
  * Load page
  */
-function loadPage()
-{
-    jQuery.ajax("./src/index.php?widgetId=" + widgetId + "&page=" + pageNumber, {
-        success: function (htmlData) {
-            jQuery("#hgMonitoringTable").empty().append(htmlData).append(function() {
-                var h = jQuery("#hgMonitoringTable").prop("scrollHeight");
-                parent.iResize(window.name, h);
-            });
-        }
-    });
-    if (autoRefresh) {
-        if (timeout) {
-            clearTimeout(timeout);
-        }
-        timeout = setTimeout(loadPage, (autoRefresh * 1000));
+function loadPage () {
+  jQuery.ajax('./src/index.php?widgetId=' + widgetId + '&page=' + pageNumber, {
+    success: function (htmlData) {
+      jQuery('#hgMonitoringTable').empty().append(htmlData).append(function () {
+        var h = jQuery('#hgMonitoringTable').prop('scrollHeight');
+        parent.iResize(window.name, h);
+      });
     }
+  });
+  if (autoRefresh) {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(loadPage, (autoRefresh * 1000));
+  }
 }

--- a/hostgroup-monitoring/src/class/HostgroupMonitoring.class.php
+++ b/hostgroup-monitoring/src/class/HostgroupMonitoring.class.php
@@ -71,6 +71,12 @@ class HostgroupMonitoring
         if (!$admin) {
             $query .= $aclObj->queryBuilder("AND", "h.host_id", $aclObj->getHostsString("ID", $this->dbb));
         }
+        if ($preferences['host_severity']) {
+            $query .= " AND h.host_id IN (SELECT host_id FROM customvariables
+                WHERE service_id IS NULL
+                AND name = 'CRITICALITY_ID'
+                AND value = " . $preferences['host_severity'] . "))";
+        }
         $query .= " ORDER BY h.name ";
         $res = $this->dbb->query($query);
         while ($row = $res->fetch()) {
@@ -122,6 +128,12 @@ class HostgroupMonitoring
             $query .= " AND h.host_id = acl.host_id
                 AND acl.service_id = s.service_id
                 AND acl.group_id IN (".$aclObj->getAccessGroupsString().")";
+        }
+        if ($preferences['host_severity']) {
+            $query .= " AND h.host_id IN (SELECT host_id FROM customvariables
+                WHERE service_id IS NULL
+                AND name = 'CRITICALITY_ID'
+                AND value = " . $preferences['host_severity'] . "))";
         }
         $query .= " ORDER BY tri, description ASC";
         $res = $this->dbb->query($query);

--- a/hostgroup-monitoring/src/data_js.js
+++ b/hostgroup-monitoring/src/data_js.js
@@ -1,40 +1,38 @@
 jQuery(function () {
 
-    if (nbRows > itemsPerPage) {
-        $("#pagination").pagination(nbRows, {
-            items_per_page: itemsPerPage,
-            current_page: pageNumber,
-            callback: paginationCallback
-        }).append("<br/>");
+  if (nbRows > itemsPerPage) {
+    $('#pagination').pagination(nbRows, {
+      items_per_page: itemsPerPage,
+      current_page: pageNumber,
+      callback: paginationCallback
+    }).append('<br/>');
+  }
+
+  $('#nbRows').html(nbCurrentItems + ' / ' + nbRows);
+
+  $('.selection').each(function () {
+    var curId = $(this).attr('id');
+    if (typeof (clickedCb[curId]) !== 'undefined') {
+      this.checked = clickedCb[curId];
     }
+  });
 
-    $("#nbRows").html(nbCurrentItems + " / " + nbRows);
+  var tmp = orderby.split(' ');
+  var icn = 'n';
+  if (tmp[1] === 'DESC') {
+    icn = 's';
+  }
+  $('[name=' + tmp[0] + ']').append('<span style="position: relative; float: right;" class="ui-icon ui-icon-triangle-1-' + icn + '"></span>');
+  $('#HostgroupTable').treeTable({
+    treeColumn: 0,
+    expandable: false
+  });
 
-    $(".selection").each(function () {
-        var curId = $(this).attr('id');
-        if (typeof (clickedCb[curId]) != 'undefined') {
-            this.checked = clickedCb[curId];
-        }
-    });
-
-    var tmp = orderby.split(' ');
-    var icn = 'n';
-    if (tmp[1] == "DESC") {
-        icn = 's';
+  function paginationCallback (pageIndex, jq) {
+    if (pageIndex !== pageNumber) {
+      pageNumber = pageIndex;
+      clickedCb = new Array();
+      loadPage();
     }
-    $("[name=" + tmp[0] + "]").append('<span style="position: relative; float: right;" class="ui-icon ui-icon-triangle-1-' + icn + '"></span>');
-    $("#HostgroupTable").treeTable({
-        treeColumn: 0,
-        expandable: false
-    });
-
-    function paginationCallback(page_index, jq)
-    {
-        if (page_index != pageNumber) {
-            pageNumber = page_index;
-            clickedCb = new Array();
-            loadPage();
-        }
-    }
-
+  }
 });

--- a/hostgroup-monitoring/src/index.php
+++ b/hostgroup-monitoring/src/index.php
@@ -146,12 +146,15 @@ $detailMode = false;
 if (isset($preferences['enable_detailed_mode']) && $preferences['enable_detailed_mode']) {
     $detailMode = true;
 }
+
 while ($row = $res->fetch()) {
     $data[$row['name']] = array(
         'name' => $row['name'],
         'hg_id' => $row['hostgroup_id'],
-        'hgurl' => "main.php?p=20201&o=svc&search=&hg=" . $row['hostgroup_id'],
-        "hgurlhost" => "main.php?p=20202&o=h&hostgroups=" . $row['hostgroup_id'],
+        'hgurl' => "main.php?p=20201&o=svc&search=&hg=" . $row['hostgroup_id'] .
+            "&host_criticality=" . $preferences['host_severity'],
+        "hgurlhost" => "main.php?p=20202&o=h&hostgroups=" . $row['hostgroup_id'] .
+            "&criticality=" . $preferences['host_severity'],
         'host_state' => array(),
         'service_state' => array()
     );

--- a/hostgroup-monitoring/src/table.ihtml
+++ b/hostgroup-monitoring/src/table.ihtml
@@ -12,6 +12,7 @@
     </tr>
     {assign var='classStyle' value='list_two'}
     {foreach key=hgId item=elem from=$data}
+    {if !empty($elem.host_state)}
     {if $classStyle == 'list_two'}
     {assign var='classStyle' value='list_one'}
     {else}
@@ -74,6 +75,7 @@
         </td>
     </tr>
     {/foreach}
+    {/if}
     {/if}
     {/foreach}
 </table>


### PR DESCRIPTION
This PR will not work if this one is not merged : 
https://github.com/centreon/centreon/pull/8181

the reason is that without the above PR when people will click on the hosts or services that are displayed in the widget they will be redirected to the monitoring and the shown data won't match the one from the widget if a host severity has been set. 