### PR TITLE
fix(monitoring): use new query parameter format for resource status l…

### DIFF
--- a/hostgroup-monitoring/src/index.php
+++ b/hostgroup-monitoring/src/index.php
@@ -170,9 +170,18 @@ $buildHostgroupUri = function (array $hostgroup, array $types, array $statuses) 
             'filter' => json_encode(
                 [
                     'criterias' => [
-                        'hostGroups' => [$hostgroup],
-                        'resourceTypes' => $types,
-                        'statuses' => $statuses,
+                        [
+                            'name' => 'host_groups',
+                            'value' => $hostgroup,
+                        ],
+                        [
+                            'name' => 'resource_types',
+                            'value' => $types,
+                        ],
+                        [
+                            'name' => 'statuses',
+                            'value' => $statuses,
+                        ]
                     ],
                 ]
             )
@@ -207,18 +216,18 @@ while ($row = $res->fetch()) {
     $data[$row['name']] = [
         'name' => $row['name'],
         'hg_id' => $row['hostgroup_id'],
-        'hg_uri' => $buildHostgroupUri($hostgroup, [], []),
-        'hg_service_uri' => $buildHostgroupUri($hostgroup, [$serviceType], []),
-        'hg_service_ok_uri' => $buildHostgroupUri($hostgroup, [$serviceType], [$okStatus]),
-        'hg_service_warning_uri' => $buildHostgroupUri($hostgroup, [$serviceType], [$warningStatus]),
-        'hg_service_critical_uri' => $buildHostgroupUri($hostgroup, [$serviceType], [$criticalStatus]),
-        'hg_service_unknown_uri' => $buildHostgroupUri($hostgroup, [$serviceType], [$unknownStatus]),
-        'hg_service_pending_uri' => $buildHostgroupUri($hostgroup, [$serviceType], [$pendingStatus]),
-        'hg_host_uri' => $buildHostgroupUri($hostgroup, [$hostType], []),
-        'hg_host_up_uri' => $buildHostgroupUri($hostgroup, [$hostType], [$upStatus]),
-        'hg_host_down_uri' => $buildHostgroupUri($hostgroup, [$hostType], [$downStatus]),
-        'hg_host_unreachable_uri' => $buildHostgroupUri($hostgroup, [$hostType], [$unreachableStatus]),
-        'hg_host_pending_uri' => $buildHostgroupUri($hostgroup, [$hostType], [$pendingStatus]),
+        'hg_uri' => $buildHostgroupUri([$hostgroup], [], []),
+        'hg_service_uri' => $buildHostgroupUri([$hostgroup], [$serviceType], []),
+        'hg_service_ok_uri' => $buildHostgroupUri([$hostgroup], [$serviceType], [$okStatus]),
+        'hg_service_warning_uri' => $buildHostgroupUri([$hostgroup], [$serviceType], [$warningStatus]),
+        'hg_service_critical_uri' => $buildHostgroupUri([$hostgroup], [$serviceType], [$criticalStatus]),
+        'hg_service_unknown_uri' => $buildHostgroupUri([$hostgroup], [$serviceType], [$unknownStatus]),
+        'hg_service_pending_uri' => $buildHostgroupUri([$hostgroup], [$serviceType], [$pendingStatus]),
+        'hg_host_uri' => $buildHostgroupUri([$hostgroup], [$hostType], []),
+        'hg_host_up_uri' => $buildHostgroupUri([$hostgroup], [$hostType], [$upStatus]),
+        'hg_host_down_uri' => $buildHostgroupUri([$hostgroup], [$hostType], [$downStatus]),
+        'hg_host_unreachable_uri' => $buildHostgroupUri([$hostgroup], [$hostType], [$unreachableStatus]),
+        'hg_host_pending_uri' => $buildHostgroupUri([$hostgroup], [$hostType], [$pendingStatus]),
         'host_state' => [],
         'service_state' => [],
     ];


### PR DESCRIPTION
…inks

This PR intends to use the query parameter format for resource status redirections

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Add the hostgroup monitoring widget
- Click on all the links that redirects to the Resource Status page and check the consistency of the filter used and the data displayed

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
