### PR TITLE
chore(build): fix build for 21.10

### DIFF
--- a/hostgroup-monitoring/configs.xml
+++ b/hostgroup-monitoring/configs.xml
@@ -4,7 +4,7 @@
     <email>contact@centreon.com</email>
     <website>http://www.centreon.com</website>
     <description>This widget displays for all host groups or a subset of groups the number of hosts and services in each status.</description>
-    <version>21.10.0-beta.1</version>
+    <version>21.10.0</version>
     <keywords>centreon, widget, hostgroup, host, monitoring</keywords>
     <screenshot></screenshot>
     <thumbnail>./widgets/hostgroup-monitoring/resources/centreon-logo.png</thumbnail>


### PR DESCRIPTION
Fixing build for the 21.10.

The version specified in the config.xml is used in the spectemplate of the widget. The spectemplate does not allow -beta.1 as version prefix